### PR TITLE
Fix possible inaccuracy for Swift Language

### DIFF
--- a/design/go2draft-generics-overview.md
+++ b/design/go2draft-generics-overview.md
@@ -822,7 +822,6 @@ The
 
 Declaring that `T` satisfies the
 [`Equatable`](https://developer.apple.com/documentation/swift/equatable) protocol makes the use of `==` in the function body valid.
-`Equatable` appears to be a built-in in Swift, not possible to define otherwise.
 
 Like Rust, Swift avoids Java’s and C#'s curiously recurring interface pattern for direct self-reference by introducing a `Self` type.
 For example, the protocol for having an `Equals` method is:


### PR DESCRIPTION
It seems that the Equatable protocol may be defined here:
https://github.com/apple/swift/blob/master/stdlib/public/core/Equatable.swift
I'm not a swift expert by any means, but it does appear that it's definable within the language.