### PR TITLE
Actually invoke `set.Make(int)`

### DIFF
--- a/design/go2draft-contracts.md
+++ b/design/go2draft-contracts.md
@@ -2323,7 +2323,7 @@ func (s Set(Elem)) Iterate(f func(Elem)) {
 Example use:
 
 ```Go
-	s := set.Make(int)
+	s := set.Make(int)()
 	s.Add(1)
 	if s.Contains(2) { panic("unexpected 2") }
 ```


### PR DESCRIPTION
Unless I missed something, `set.Make(int)` seems like it would be a function of type `func () set.Set(int)`, which needs to be invoked as `set.Make(int)()` to actually construct the set?