### PR TITLE
fix typo: method receiver should contain type arguments, not parameters

### DIFF
--- a/design/go2draft-type-parameters.md
+++ b/design/go2draft-type-parameters.md
@@ -3274,7 +3274,7 @@ type Iterator[K, V any] struct {
 // Next returns the next key and value pair. The bool result reports
 // whether the values are valid. If the values are not valid, we have
 // reached the end.
-func (it *Iterator[K, V any]) Next() (K, V, bool) {
+func (it *Iterator[K, V]) Next() (K, V, bool) {
 	kv, ok := it.r.Next()
 	return kv.k, kv.v, ok
 }


### PR DESCRIPTION
From what I understand, type parameters can only be used in a type or a function declaration. Thus, in a method receiver, one can only find type arguments. Having `*Iterator[K, V any]` there looks like a little typo to me. The go2go Playground seems to agree with me: [before](https://go2goplay.golang.org/p/dekNQ6Xy8XM) there's a parse error while there's no [after](https://go2goplay.golang.org/p/4B8iTq2AeET).