### PR TITLE
Create 50649-get-credentials-from-netrc

### DIFF
--- a/design/50649-get-credentials-from-netrc
+++ b/design/50649-get-credentials-from-netrc
@@ -1,7 +1,7 @@
 
-# Proposal: [Title]
+# Proposal: Get Credentials from netrc
 
-Author(s): [Author Name, Co-Author Name]
+Author(s): ZhiFeng Hu
 
 Last updated: [2021-01-17]
 

--- a/design/50649-get-credentials-from-netrc
+++ b/design/50649-get-credentials-from-netrc
@@ -1,0 +1,48 @@
+
+# Proposal: [Title]
+
+Author(s): [Author Name, Co-Author Name]
+
+Last updated: [2021-01-17]
+
+Discussion at https://golang.org/issue/50649.
+
+## Abstract
+
+To expose the credentials from netrc file will be very useful for any custom app who want to get them.
+
+
+## Background
+
+The current auth.go does not expose an api to get matched host username/credential from netrc 
+
+## Proposal
+
+Add new API `GetCredentials`,  it's behaviour like the same of the `AddCredentials` api
+
+## Rationale
+
+It's not any break changes or harmful for i know, please let me know if any problem.
+
+## Compatibility
+
+[A discussion of the change with regard to the
+[compatibility guidelines](https://golang.org/doc/go1compat).]
+
+Initial support since golang 1.17 or newer .
+
+## Implementation
+
+[A description of the steps in the implementation, who will do them, and when.
+This should include a discussion of how the work fits into [Go's release cycle](https://golang.org/wiki/Go-Release-Cycle).]
+The CR code has submit to gerrit.
+https://go-review.googlesource.com/c/go/+/373396/1/src/cmd/go/internal/auth/auth.go#12
+
+## Open issues (if applicable)
+
+[A discussion of issues relating to this proposal for which the author does not
+know the solution. This section may be omitted if there are none.]
+
+Other issue tracking the related issue:
+
+https://github.com/golang/go/issues/26232


### PR DESCRIPTION
The document describe changes for  
https://go-review.googlesource.com/c/go/+/373396/1/src/cmd/go/internal/auth/auth.go#12

and issue :
https://github.com/golang/go/issues/50649

