### PR TITLE
design/51082-godocfmt: remove <style> tag

### DIFF
--- a/design/51082-godocfmt.md
+++ b/design/51082-godocfmt.md
@@ -14,10 +14,6 @@ It includes a new package, `go/doc/comment`, exposing a parsed syntax tree for
 doc comments, and it includes changes to `go/printer` and therefore `gofmt`
 to format doc comments in a standard way.
 
-<style>
-th, td { vertical-align: top; }
-</style>
-
 For example, existing lists reformat from the display on the left to the one on the right:
 
 <table>


### PR DESCRIPTION
The doc recommends to view it on GitHub because Gerrit's Markdown
viewer does not render the images. GitHub does not support the
<style> tag and renders it as plain text.

The style is supposed to change the vertical-align of the <th> and
<td> elements. But the table is rendered perfectly without this style.