### PR TITLE
design/68723-crypto-ssh-v2.md: change NewPublicKey signature

### DIFF
--- a/design/68723-crypto-ssh-v2.md
+++ b/design/68723-crypto-ssh-v2.md
@@ -425,6 +425,10 @@ func MarshalPrivateKey(key crypto.PrivateKey, options MarshalPrivateKeyOptions) 
 
 This way we can remove `MarshalPrivateKeyWithPassphrase` because the passphrase is now an option. We can easily add support for other options, for example making salt rounds confgurable, see [golang/go#68700](https://github.com/golang/go/issues/68700).
 
+### NewPublicKey
+
+Change the `NewPublicKey` signature to accept `crypto.PublicKey` instead of an empty interface. All public keys in the standard library implement this interface.
+
 ### Deprecated API and algorithms removal
 
 We'll remove DSA support, see [here](https://lists.mindrot.org/pipermail/openssh-unix-announce/2024-January/000156.html) for DSA status in OpenSSH, it is already disabled by default and will be removed in January, 2025.

--- a/design/68723/ssh.html
+++ b/design/68723/ssh.html
@@ -777,7 +777,7 @@ so its API may be changed when pressing needs arise.
   <li>
       <a href="#PublicKey">type PublicKey</a>
       <ul>
-          <li><a href="#NewPublicKey">func NewPublicKey(key interface{}) (PublicKey, error)</a></li>
+          <li><a href="#NewPublicKey">func NewPublicKey(key crypto.PublicKey) (PublicKey, error)</a></li>
           <li><a href="#ParseAuthorizedKey">func ParseAuthorizedKey(in []byte) (out PublicKey, comment string, options []string, rest []byte, err error)</a></li>
           <li><a href="#ParseKnownHosts">func ParseKnownHosts(in []byte) (marker string, hosts []string, pubKey PublicKey, comment string, rest []byte, ...)</a></li>
           <li><a href="#ParsePublicKey">func ParsePublicKey(in []byte) (out PublicKey, err error)</a></li>
@@ -1986,10 +1986,10 @@ encoded private key and passphrase. It supports the same keys as
     <p>PublicKey represents a public key using an unspecified algorithm.
 <p>Some PublicKeys provided by this package also implement CryptoPublicKey.
 <h4 id="NewPublicKey">func NewPublicKey</h4>
-  <pre class="chroma"><span class="kd">func</span> <span class="nf">NewPublicKey</span><span class="p">(</span><span class="nx">key</span> <span class="kd">interface</span><span class="p">{})</span> <span class="p">(</span><a href="#PublicKey"><span class="nx">PublicKey</span></a><span class="p">,</span> <a href="https://pkg.go.dev/builtin#error"><span class="kt">error</span></a><span class="p">)</span></pre>
-  <p>NewPublicKey takes an *rsa.PublicKey, *dsa.PublicKey, *ecdsa.PublicKey,
-or ed25519.PublicKey returns a corresponding PublicKey instance.
-ECDSA keys must use P-256, P-384 or P-521.
+<pre class="chroma"><span class="kd">func</span> <span class="nf">NewPublicKey</span><span class="p">(</span><span class="nx">key</span> <a href="https://pkg.go.dev/crypto"><span class="nx">crypto</span></a><span class="p">.</span><a href="https://pkg.go.dev/crypto#PublicKey"><span class="nx">PublicKey</span></a><span class="p">)</span> <span class="p">(</span><a href="#PublicKey"><span class="nx">PublicKey</span></a><span class="p">,</span> <a href="https://pkg.go.dev/builtin#error"><span class="kt">error</span></a><span class="p">)</span></pre>
+  <p>NewPublicKey takes an *rsa.PublicKey, *ecdsa.PublicKey, or ed25519.PublicKey
+returns a corresponding PublicKey instance. ECDSA keys must use P-256, P-384
+or P-521.
 <h4 id="ParseAuthorizedKey">func ParseAuthorizedKey</h4>
   <pre class="chroma"><span class="kd">func</span> <span class="nf">ParseAuthorizedKey</span><span class="p">(</span><span class="nx">in</span> <span class="p">[]</span><a href="https://pkg.go.dev/builtin#byte"><span class="kt">byte</span></a><span class="p">)</span> <span class="p">(</span><span class="nx">out</span> <a href="#PublicKey"><span class="nx">PublicKey</span></a><span class="p">,</span> <span class="nx">comment</span> <a href="https://pkg.go.dev/builtin#string"><span class="kt">string</span></a><span class="p">,</span> <span class="nx">options</span> <span class="p">[]</span><a href="https://pkg.go.dev/builtin#string"><span class="kt">string</span></a><span class="p">,</span> <span class="nx">rest</span> <span class="p">[]</span><a href="https://pkg.go.dev/builtin#byte"><span class="kt">byte</span></a><span class="p">,</span> <span class="nx">err</span> <a href="https://pkg.go.dev/builtin#error"><span class="kt">error</span></a><span class="p">)</span></pre>
   <p>ParseAuthorizedKey parses a public key from an authorized_keys


### PR DESCRIPTION
It now accepts a crypto.PublicKey instead of an empty interface. 
All public keys in the standard library implement this interface.